### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ easydict
 h5py
 matplotlib
 numpy
-open3d==0.9
+open3d==0.10
 opencv-python
 pyyaml
 scipy


### PR DESCRIPTION
Fixed open3d by adding version 0.10 instead of 0.09.

"Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com
ERROR: Could not find a version that satisfies the requirement open3d==0.9 (from versions: none)
ERROR: No matching distribution found for open3d==0.9"